### PR TITLE
Add dynamic replica scaling

### DIFF
--- a/autoscaler.xml
+++ b/autoscaler.xml
@@ -55,16 +55,27 @@ payload.access_token]]></dw:set-payload>
                 <!-- Save token for use in API call -->
                 <set-variable variableName="accessToken" value="#[payload]" doc:name="Store Access Token" />
 
-                <!-- Define new resource allocation -->
-                <set-payload doc:name="Prepare Scale Payload">
-                    <![CDATA[{
-                      "replicas": 3,
-                      "resources": {
-                        "cpu": "1.0",
-                        "memory": "2.0Gi"
-                      }
-                    }]]>
-                </set-payload>
+                <!-- Retrieve current app information to calculate new replica count -->
+                <http:request method="GET" doc:name="Get Current App" url="https://anypoint.mulesoft.com/runtimefabric/api/v2/organizations/#[(p('org.id'))]/environments/#[(p('env.id'))]/applications/#[(p('app.id'))]">
+                    <http:request-builder>
+                        <http:header headerName="Authorization" value="Bearer #[vars.accessToken]" />
+                    </http:request-builder>
+                </http:request>
+
+                <!-- Prepare request payload with one additional replica -->
+                <dw:transform-message doc:name="Prepare Scale Payload">
+                    <dw:set-payload><![CDATA[%dw 2.0
+output application/json
+var current = payload.replicas default 1
+---
+{
+  replicas: (current as Number) + 1,
+  resources: {
+    cpu: "1.0",
+    memory: "2.0Gi"
+  }
+}]]></dw:set-payload>
+                </dw:transform-message>
 
                 <!-- Call Runtime Manager API to scale up the application -->
                 <http:request method="PATCH" doc:name="Scale App" url="https://anypoint.mulesoft.com/runtimefabric/api/v2/organizations/#[(p('org.id'))]/environments/#[(p('env.id'))]/applications/#[(p('app.id'))]">

--- a/src/test/munit/autoscale-flow-test.xml
+++ b/src/test/munit/autoscale-flow-test.xml
@@ -34,6 +34,14 @@
                     <munit-tools:payload value="#[{ access_token: 'token' }]" />
                 </munit-tools:then-return>
             </munit-tools:mock-when>
+            <munit-tools:mock-when processor="http:request">
+                <munit-tools:with-attributes>
+                    <munit-tools:equal-to expression="#[attributes.method]" expectedValue="GET" />
+                </munit-tools:with-attributes>
+                <munit-tools:then-return>
+                    <munit-tools:payload value="#[{ replicas: 2 }]" />
+                </munit-tools:then-return>
+            </munit-tools:mock-when>
 
             <set-payload doc:name="Set Webhook Payload" value="#[{ event: { appName: 'test-app', value: 85 } }]" />
         </munit:behavior>
@@ -68,6 +76,14 @@
                 </munit-tools:with-attributes>
                 <munit-tools:then-return>
                     <munit-tools:payload value="#[{ access_token: 'token' }]" />
+                </munit-tools:then-return>
+            </munit-tools:mock-when>
+            <munit-tools:mock-when processor="http:request">
+                <munit-tools:with-attributes>
+                    <munit-tools:equal-to expression="#[attributes.method]" expectedValue="GET" />
+                </munit-tools:with-attributes>
+                <munit-tools:then-return>
+                    <munit-tools:payload value="#[{ replicas: 2 }]" />
                 </munit-tools:then-return>
             </munit-tools:mock-when>
 


### PR DESCRIPTION
## Summary
- add logic to read current replica count and add one replica when scaling
- update MUnit tests to mock new GET call

## Testing
- `mvn -q test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_683f72d78030832c8884b9031386a2ba